### PR TITLE
Update Docker run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ BlazingQuartz is created with [ASP.NET Core Blazor Server](https://blazor.net) a
     ```
     docker run -d \
     --name=BlazingQuartzApp \
-    -e TZ=<your_timezone>
+    -e TZ=<your_timezone> \
     -v /<blazingquartz_path>/BlazingQuartzDb.db:/app/BlazingQuartzDb.db \
     -v /<blazingquartz_path>/logs:/app/logs \
     -v /<blazingquartz_path>/certs:/app/certs \


### PR DESCRIPTION
Ensure proper line continuation by adding a backslash at the end of the -e TZ=<your_timezone> line in the Docker run command in the README.